### PR TITLE
Append short code to call-url

### DIFF
--- a/provider/defaultprovider/default_provider.go
+++ b/provider/defaultprovider/default_provider.go
@@ -4,12 +4,13 @@ import (
 	openapi "github.com/go-openapi/runtime/client"
 
 	"fmt"
+	"net/http"
+	"net/url"
+
 	"github.com/fnproject/fn_go/client"
 	"github.com/fnproject/fn_go/client/version"
 	"github.com/fnproject/fn_go/provider"
 	"github.com/go-openapi/strfmt"
-	"net/http"
-	"net/url"
 )
 
 // Provider is the default Auth provider
@@ -53,7 +54,7 @@ func (dp *Provider) WrapCallTransport(t http.RoundTripper) http.RoundTripper {
 	return t
 }
 
-func (dp *Provider) CallURL() *url.URL {
+func (dp *Provider) CallURL(appName string) *url.URL {
 	return dp.CallUrl
 }
 func (dp *Provider) APIURL() *url.URL {

--- a/provider/defaultprovider/default_provider.go
+++ b/provider/defaultprovider/default_provider.go
@@ -54,8 +54,8 @@ func (dp *Provider) WrapCallTransport(t http.RoundTripper) http.RoundTripper {
 	return t
 }
 
-func (dp *Provider) CallURL(appName string) *url.URL {
-	return dp.CallUrl
+func (dp *Provider) CallURL(appName string) (*url.URL, error) {
+	return dp.CallUrl, nil
 }
 func (dp *Provider) APIURL() *url.URL {
 	return dp.FnApiUrl

--- a/provider/oracle/oracle_provider.go
+++ b/provider/oracle/oracle_provider.go
@@ -9,11 +9,10 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"time"
-
-	"net/url"
 
 	fnclient "github.com/fnproject/fn_go/client"
 	apiapps "github.com/fnproject/fn_go/client/apps"
@@ -132,19 +131,6 @@ func (op *Provider) CallURL(appName string) (*url.URL, error) {
 	op.FnCallUrl.Host = annons.ShortCode + "." + op.FnCallUrl.Host
 
 	return op.FnCallUrl, err
-}
-
-func getMockJsonFile() string {
-	var data []byte
-	data, err := ioutil.ReadFile("~/.fn/api-mock.json")
-	if err != nil {
-		fmt.Println("Err: ", err)
-	}
-
-	var resp Response
-	_ = json.Unmarshal(data, &resp)
-
-	return resp.Annotations.ShortCode
 }
 
 func (op *Provider) APIURL() *url.URL {

--- a/provider/oracle/oracle_provider.go
+++ b/provider/oracle/oracle_provider.go
@@ -142,8 +142,7 @@ func (op *Provider) CallURL(appName string) *url.URL {
 
 func getMockJsonFile() string {
 	var data []byte
-	wd, _ := os.Getwd()
-	data, err := ioutil.ReadFile(wd + "~/.fn/api-data.json")
+	data, err := ioutil.ReadFile("~/.fn/api-data.json")
 	if err != nil {
 		fmt.Println("Err: ", err)
 	}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -31,7 +31,7 @@ type Provider interface {
 	// APIURL returns the current API URL base to use with this provider
 	APIURL() *url.URL
 	// CallURL returns the default Call URL base to use with this provider
-	CallURL(string) *url.URL
+	CallURL(string) (*url.URL, error)
 	// WrapCallTransport adds any request signing or auth to an existing round tripper for calls
 	WrapCallTransport(http.RoundTripper) http.RoundTripper
 	APIClient() *client.Fn

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -2,11 +2,12 @@ package provider
 
 import (
 	"fmt"
-	"github.com/fnproject/fn_go/client"
-	"github.com/fnproject/fn_go/client/version"
 	"net/http"
 	"net/url"
 	"strings"
+
+	"github.com/fnproject/fn_go/client"
+	"github.com/fnproject/fn_go/client/version"
 )
 
 // ProviderFunc constructs a provider
@@ -30,7 +31,7 @@ type Provider interface {
 	// APIURL returns the current API URL base to use with this provider
 	APIURL() *url.URL
 	// CallURL returns the default Call URL base to use with this provider
-	CallURL() *url.URL
+	CallURL(string) *url.URL
 	// WrapCallTransport adds any request signing or auth to an existing round tripper for calls
 	WrapCallTransport(http.RoundTripper) http.RoundTripper
 	APIClient() *client.Fn


### PR DESCRIPTION
When a function is called from the CLI, the unique app shortcode, which is returned as an annotation from a GET request on an app, is appended to the call URL. The call URL is retrieved from a provider-specific context file.

call-url: `https://<shortcode>.{some-call-url}/r/app/route`

