### PR TITLE
Regenerate app models following fn swagger spec change

### DIFF
--- a/modelsv2/app.go
+++ b/modelsv2/app.go
@@ -37,7 +37,7 @@ type App struct {
 	Name string `json:"name,omitempty"`
 
 	// A comma separated list of syslog urls to send all function logs to. supports tls, udp or tcp. e.g. tls://logs.papertrailapp.com:1
-	SyslogURL string `json:"syslog_url,omitempty"`
+	SyslogURL *string `json:"syslog_url,omitempty"`
 
 	// Most recent time that app was updated. Always in UTC.
 	// Read Only: true


### PR DESCRIPTION
This is the code generation change corresponding to https://github.com/fnproject/fn/pull/1346

Note that this is a backwards-incompatible change for the generated code, due to how the golang swagger generator represents nullable strings. Any client of `fn_go` which accesses the `SyslogURL` field will face compilation issues as a result of this change.