### PR TITLE
Invoke API

### DIFF
--- a/provider/defaultprovider/default_provider.go
+++ b/provider/defaultprovider/default_provider.go
@@ -1,6 +1,8 @@
 package defaultprovider
 
 import (
+	"io"
+
 	openapi "github.com/go-openapi/runtime/client"
 
 	"net/http"
@@ -68,4 +70,8 @@ func (op *Provider) VersionClient() *version.Client {
 	runtime := openapi.New(op.FnApiUrl.Host, "/", []string{op.FnApiUrl.Scheme})
 	runtime.Transport = op.WrapCallTransport(runtime.Transport)
 	return version.New(runtime, strfmt.Default)
+}
+
+func (op *Provider) Invoke(invokeURL string, content io.Reader, output io.Writer, headers http.Header, contentType string, debug bool) error {
+	return provider.Invoke(op, invokeURL, content, output, headers, contentType, debug)
 }

--- a/provider/oracle/oracle_provider.go
+++ b/provider/oracle/oracle_provider.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -336,4 +337,8 @@ func getPrivateKey(keyBytes []byte, pKeyPword, pkeyFilePath string) (*rsa.Privat
 	}
 
 	return key, nil
+}
+
+func (op *Provider) Invoke(invokeURL string, content io.Reader, output io.Writer, headers http.Header, contentType string, debug bool) error {
+	return provider.Invoke(op, invokeURL, content, output, headers, contentType, debug)
 }

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -133,7 +133,7 @@ func Invoke(provider Provider, invokeURL string, content io.Reader, output io.Wr
 		if err != nil {
 			return err
 		}
-		fmt.Printf(string(b) + "\n")
+		io.WriteString(os.Stderr, string(b)+"\n")
 	}
 
 	resp, err := httpClient.Do(req)
@@ -147,7 +147,7 @@ func Invoke(provider Provider, invokeURL string, content io.Reader, output io.Wr
 		if err != nil {
 			return err
 		}
-		fmt.Printf(string(b) + "\n")
+		io.WriteString(os.Stderr, string(b)+"\n")
 	}
 
 	// for sync calls

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -119,11 +119,10 @@ func Invoke(provider Provider, invokeURL string, content io.Reader, output io.Wr
 		}
 	}
 
-	req.Header = headers
-	if contentType != "" {
-		req.Header.Set("Content-Type", contentType)
-	} else {
-		req.Header.Set("Content-Type", "text/plain")
+	for key, v := range headers {
+		for _, value := range v {
+			req.Header.Add(key, value)
+		}
 	}
 
 	transport := provider.WrapCallTransport(http.DefaultTransport)

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -1,14 +1,22 @@
 package provider
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"net/http"
+	"net/http/httputil"
 	"net/url"
+	"os"
 	"strings"
 
 	"github.com/fnproject/fn_go/client/version"
 	"github.com/fnproject/fn_go/clientv2"
 )
+
+const MaximumRequestBodySize = 5 * 1024 * 1024
 
 // ProviderFunc constructs a provider
 type ProviderFunc func(config ConfigSource, source PassPhraseSource) (Provider, error)
@@ -34,6 +42,7 @@ type Provider interface {
 	WrapCallTransport(http.RoundTripper) http.RoundTripper
 	APIClientv2() *clientv2.Fn
 	VersionClient() *version.Client
+	Invoke(invokeURL string, content io.Reader, output io.Writer, headers http.Header, contentType string, debug bool) error
 }
 
 // CanonicalFnAPIUrl canonicalises an *FN_API_URL  to a default value
@@ -75,4 +84,102 @@ func (c *Providers) ProviderFromConfig(id string, source ConfigSource, phraseSou
 		return nil, fmt.Errorf("No provider with id  '%s' is registered", id)
 	}
 	return p(source, phraseSource)
+}
+
+type apiErr struct {
+	Message string `json:"message"`
+}
+type callID struct {
+	CallID string `json:"call_id"`
+	Error  apiErr `json:"error"`
+}
+
+func Invoke(provider Provider, invokeURL string, content io.Reader, output io.Writer, headers http.Header, contentType string, debug bool) error {
+
+	method := "POST"
+
+	// Read the request body (up to the maximum size), as this is used in the
+	// authentication signature
+	var req *http.Request
+	if content != nil {
+		b, err := ioutil.ReadAll(io.LimitReader(content, MaximumRequestBodySize))
+		if err != nil {
+			return err
+		}
+		buffer := bytes.NewBuffer(b)
+		req, err = http.NewRequest(method, invokeURL, buffer)
+		if err != nil {
+			return fmt.Errorf("Error creating request to service: %s", err)
+		}
+	} else {
+		var err error
+		req, err = http.NewRequest(method, invokeURL, nil)
+		if err != nil {
+			return fmt.Errorf("Error creating request to service: %s", err)
+		}
+	}
+
+	req.Header = headers
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	} else {
+		req.Header.Set("Content-Type", "text/plain")
+	}
+
+	transport := provider.WrapCallTransport(http.DefaultTransport)
+	httpClient := http.Client{Transport: transport}
+
+	if debug {
+		b, err := httputil.DumpRequestOut(req, content != nil)
+		if err != nil {
+			return err
+		}
+		fmt.Printf(string(b) + "\n")
+	}
+
+	resp, err := httpClient.Do(req)
+
+	if err != nil {
+		return fmt.Errorf("Error invoking fn: %s", err)
+	}
+
+	if debug {
+		b, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return err
+		}
+		fmt.Printf(string(b) + "\n")
+	}
+
+	// for sync calls
+	if call_id, found := resp.Header["FN_CALL_ID"]; found {
+		if debug {
+			fmt.Fprint(os.Stderr, fmt.Sprintf("Call ID: %v\n", call_id[0]))
+		}
+		io.Copy(output, resp.Body)
+	} else {
+		// for async calls and error discovering
+		c := &callID{}
+		err = json.NewDecoder(resp.Body).Decode(c)
+		if err == nil {
+			// decode would not fail in both cases:
+			// - call id in body
+			// - error in body
+			// that's why we need to check values of attributes
+			if c.CallID != "" {
+				fmt.Fprint(os.Stderr, fmt.Sprintf("Call ID: %v\n", c.CallID))
+			} else {
+				fmt.Fprint(output, fmt.Sprintf("Error: %v\n", c.Error.Message))
+			}
+		} else {
+			return err
+		}
+	}
+
+	if resp.StatusCode >= 400 {
+		// TODO: parse out error message
+		return fmt.Errorf("Error calling function: status %v", resp.StatusCode)
+	}
+
+	return nil
 }


### PR DESCRIPTION
Moving Invoke API from CLI to fn_go (where it belong).

Changes being made:
 - extending provider interface with `Invoke` method
 - `Invoke` method signature is different from what it was in CLI (see changes to `headers` and no `method` thing)

Purpose of this change is not to move away from the CLI as a dependency within Golang apps where I'd like to use providers from fn_go and call functions with authorization.
