### PR TITLE
Use FnApiUrl.Path when getting server version (fnproject/fn#1339)

### DIFF
--- a/provider/defaultprovider/default_provider.go
+++ b/provider/defaultprovider/default_provider.go
@@ -65,7 +65,7 @@ func (dp *Provider) APIClient() *clientv2.Fn {
 }
 
 func (op *Provider) VersionClient() *version.Client {
-	runtime := openapi.New(op.FnApiUrl.Host, "/", []string{op.FnApiUrl.Scheme})
+	runtime := openapi.New(op.FnApiUrl.Host, op.FnApiUrl.Path, []string{op.FnApiUrl.Scheme})
 	runtime.Transport = op.WrapCallTransport(runtime.Transport)
 	return version.New(runtime, strfmt.Default)
 }


### PR DESCRIPTION
This issue fixes a bug that was preventing the CLI (and any other libraries that use this) from finding the server version when the server was accessed using a non-root path c.f. fnproject/fn#1339.

As you can see, before the change the server version is `?` when using a non-root path:

```
vzarola-Mac:testing vzarola$ echo $FN_API_URL
http://127.0.0.1:8888/fn/
vzarola-Mac:testing vzarola$ fn version
Client version is latest version: 0.5.69
Server version:  ?
```

This is because the cli was trying request `/version` as shown by the logs from the reverse proxy I was using:
```
CONNECT   Apr 04 20:35:16 [85721]: Request (file descriptor 10): GET /version HTTP/1.1
```

Once I made this change and recompiled the cli the output of the command is now as follows:
```
vzarola-Mac:testing vzarola$ echo $FN_API_URL
http://127.0.0.1:8888/fn/
vzarola-Mac:testing vzarola$ fn version
Client version is latest version: 0.5.69
Server version:  0.3.687
```

And the logs from the reverse proxy show it's correctly requesting `/fn/version`:
```
CONNECT   Apr 04 20:33:58 [85721]: Request (file descriptor 10): GET /fn/version HTTP/1.1
```

The cli is also working when no `$FN_API_URL` is set:

```
vzarola-Mac:testing vzarola$ unset FN_API_URL
vzarola-Mac:testing vzarola$ fn version
Client version is latest version: 0.5.69
Server version:  0.3.687
```

And it also works if I start the server on another port try with no path:
```
vzarola-Mac:testing vzarola$ export FN_API_URL=http://localhost:8081
vzarola-Mac:testing vzarola$ fn version
Client version is latest version: 0.5.69
Server version:  0.3.687
```