### PR TITLE
Remove v1 hack from CanonicalFnAPIUrl

### DIFF
--- a/provider/provider.go
+++ b/provider/provider.go
@@ -57,14 +57,6 @@ func CanonicalFnAPIUrl(urlStr string) (*url.URL, error) {
 		}
 	}
 
-	//Remove /v1 from any paths here internal URL is now base URL
-
-	if strings.HasSuffix(parseUrl.Path, "/v1") {
-		parseUrl.Path = strings.TrimSuffix(parseUrl.Path, "v1")
-	} else if strings.HasSuffix(parseUrl.Path, "/v1/") {
-		parseUrl.Path = strings.TrimSuffix(parseUrl.Path, "v1/")
-	}
-
 	return parseUrl, nil
 }
 

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -12,14 +12,14 @@ func TestCanonicaliseUrlURL(t *testing.T) {
 		port   string
 		path   string
 	}{
-		{"http://localhost:8080/v1", "http", "localhost", "8080", "/"},
+		{"http://localhost:8080/v1", "http", "localhost", "8080", "/v1"},
 		{"http://localhost:8080", "http", "localhost", "8080", ""},
 		{"http://localhost", "http", "localhost", "80", ""},
 		{"localhost", "http", "localhost", "80", ""},
 		{"localhost:8080", "http", "localhost", "8080", ""},
-		{"localhost/v1", "http", "localhost", "80", "/"},
+		{"localhost/v1", "http", "localhost", "80", "/v1"},
 		{"localhost/", "http", "localhost", "80", "/"},
-		{"https://localhost/v1", "https", "localhost", "443", "/"},
+		{"https://localhost/v1", "https", "localhost", "443", "/v1"},
 		{"https://someprovider/specificversion/withasubpath", "https", "someprovider", "443", "/specificversion/withasubpath"},
 		{"https://someprovider:450/specificversion/withasubpath", "https", "someprovider", "450", "/specificversion/withasubpath"},
 	}


### PR DESCRIPTION
The v1 API is no longer supported so we can now remove this hack. C.f. the discussion on [pull request 30](https://github.com/fnproject/fn_go/pull/30#issuecomment-480202350) and the issue: fnproject/fn#1347.

Before this change, if the `FN_API_URL` was set to anything ending in `/v1` e.g. `http://localhost:8888/fn-routing/v1/` then it wouldn't work:

```
# Sever is running on localhost:8081
# Reverse proxy is sending localhost:8888:fn-routing/v1/ -> localhost:8081

vzarola-Mac:~ vzarola$ echo $FN_API_URL
http://localhost:8888/fn-routing/v1/
vzarola-Mac:~ vzarola$ fn version
Client version is latest version: 0.5.71
Server version:  ?

Proxy logs:

INFO      Apr 10 11:54:43 [17970]: Added reverse proxy rule: /fn-routing/v1/ -> http://127.0.0.1:8081/
CONNECT   Apr 10 11:56:38 [17979]: Request (file descriptor 10): GET /fn-routing/version HTTP/1.1
ERROR     Apr 10 11:56:38 [17979]: Bad request, no mapping for '/fn-routing/version' found


vzarola-Mac:~ vzarola$ fn list app

Fn: no consumer: "text/html"

vzarola-Mac:~ vzarola$ fn invoke testpython testpython

Fn: no consumer: "text/html"
```

After this change it is working as expected:
```
# Sever is running on localhost:8081
# Reverse proxy is sending localhost:8888:fn-routing/v1/ -> localhost:8081

vzarola-Mac:~ vzarola$ fn version
Client version is latest version: 0.5.71
Server version:  0.3.687

CONNECT   Apr 10 11:57:52 [17976]: Rewriting URL: /fn-routing/v1/version -> http://127.0.0.1:8081/version

vzarola-Mac:~ vzarola$ fn list app
NAME		ID
testapp		01D7MD7GTBNG8G00GZJ0000001
testpython	01D7PVG04HNG8G00GZJ0000001

vzarola-Mac:~ vzarola$ fn invoke testpython testpython
{"host": "localhost", "user-agent": "Go-http-client/1.1", "content-length": "0", "accept-encoding": "gzip", "content-type": "text/plain", "fn-call-id": "01D83ECV1BNG8G00GZJ0000001", "fn-deadline": "2019-04-10T10:59:16Z"}
```

I have also updated the unit tests accordingly which can be tested with `cd provider && go test`

N.b. you'll need my changes from fnproject/fn_go#30 in order for `fn version` to work with paths.