### PR TITLE
Add the opc-compartment-id header to the oracle provider

### DIFF
--- a/provider/oracle/oracle_provider.go
+++ b/provider/oracle/oracle_provider.go
@@ -149,7 +149,7 @@ func (op *Provider) WrapCallTransport(roundTripper http.RoundTripper) http.Round
 		roundTripper = InsecureRoundTripper(roundTripper)
 	}
 
-	ociClient := common.RequestSigner(op.KP, []string{"host", "date", "(request-target)"}, []string{"content-length", "content-type", "x-content-sha256"})
+	ociClient := common.RequestSigner(op.KP, []string{"host", "date", "(request-target)", "opc-compartment-id"}, []string{"content-length", "content-type", "x-content-sha256"})
 
 	signingRoundTrripper := ociSigningRoundTripper{
 		transport: roundTripper,


### PR DESCRIPTION
Close a gap in the request signature; `opc-compartment-id` is a critical header and should be in the set of signed inputs.