### PR TITLE
OCI shim: fix blank digest behaviour

### DIFF
--- a/provider/oracle/shim/client/client_mock.go
+++ b/provider/oracle/shim/client/client_mock.go
@@ -329,6 +329,9 @@ func NewMockFunctionsManagementClientBasic(ctrl *gomock.Controller) FunctionsMan
 				digest := "OriginalFunctionDigest"
 				if request.ImageDigest != nil {
 					digest = *request.ImageDigest
+					if digest == "" {
+						return functions.UpdateFunctionResponse{}, fmt.Errorf("invalid image digest")
+					}
 				}
 				memory := int64(128)
 				if request.MemoryInMBs != nil {

--- a/provider/oracle/shim/fns.go
+++ b/provider/oracle/shim/fns.go
@@ -230,6 +230,10 @@ func parseDigestAnnotation(annotations map[string]interface{}) (*string, error) 
 		return nil, fmt.Errorf("invalid image digest")
 	}
 
+	if digest == "" {
+		return nil, nil
+	}
+
 	return &digest, nil
 }
 

--- a/provider/oracle/shim/fns_test.go
+++ b/provider/oracle/shim/fns_test.go
@@ -287,3 +287,26 @@ func TestUpdateFnImage(t *testing.T) {
 	assert.Equal(t, uint64(128), result.Memory)
 	assert.Equal(t, int32(30), *result.Timeout)
 }
+
+func TestUpdateFnBlankDigest(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	c := client.NewMockFunctionsManagementClientBasic(ctrl)
+	shim := NewFnsShim(c)
+
+	fn := modelsv2.Fn{
+		Annotations: map[string]interface{}{
+			annotationImageDigest: "",
+		},
+	}
+
+	fnId := "UpdateFnId"
+	updateFnOK, err := shim.UpdateFn(&fns.UpdateFnParams{
+		FnID: fnId,
+		Body: &fn,
+	})
+	assert.NoError(t, err)
+	result := updateFnOK.GetPayload()
+	assert.NotEmpty(t, result.Annotations[annotationImageDigest])
+}


### PR DESCRIPTION
In order to replicate the behaviour of the OSS endpoints, we don't set digest in the body if a blank string is passed

Fn CLI 0.5.102 (pre-shim):
```
$ /usr/local/bin/fn update fn syslogTest testfunc --annotation oracle.com/oci/imageDigest='""'
syslogTest testfunc updated
```

Fn CLI 0.6.0 (shim, before fix):
```
$ ./fn update fn debugtest hello-go --annotation oracle.com/oci/imageDigest='""'

Fn: Service error:InvalidParameter. imageDigest is invalid. . http status code: 400. Opc request id: ...

See 'fn <command> --help' for more information. Client version: 0.6.0
```

Fn CLI with this fix:
```
$ ./fn update fn debugtest hello-go --annotation oracle.com/oci/imageDigest='""'
debugtest hello-go updated
```