### PR TITLE
Ensure http client Transport is defined before trying to set InsecureSkipVerify

### DIFF
--- a/provider/oracle/oracle_common.go
+++ b/provider/oracle/oracle_common.go
@@ -143,16 +143,20 @@ func (t ociSigningRoundTripper) intercept(request *http.Request) (err error) {
 
 // Skip verification of insecure certs
 func InsecureRoundTripper(roundTripper http.RoundTripper) http.RoundTripper {
-	transport := roundTripper.(*http.Transport)
-	if transport != nil {
+	if roundTripper == nil {
+		roundTripper = http.DefaultTransport
+	}
+
+	if transport, ok := roundTripper.(*http.Transport); ok {
 		if transport.TLSClientConfig != nil {
 			transport.TLSClientConfig.InsecureSkipVerify = true
 		} else {
 			transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 		}
+		return transport
 	}
 
-	return transport
+	return nil
 }
 
 //-- Provider interface impl ----------------------------------------------------------------------------------

--- a/provider/oracle/oracle_common_test.go
+++ b/provider/oracle/oracle_common_test.go
@@ -1,0 +1,26 @@
+package oracle
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestInsecureRoundTripper(t *testing.T) {
+	testCases := []http.RoundTripper{
+		http.DefaultTransport, // Normal case
+		nil,                   // Ensure it creates a DefaultTransport in the nil case
+	}
+
+	for _, transport := range testCases {
+		roundTripper := InsecureRoundTripper(transport)
+		transport, ok := roundTripper.(*http.Transport)
+
+		if !ok {
+			t.Fatal("Transport not correctly returned")
+		}
+
+		if transport.TLSClientConfig == nil || !transport.TLSClientConfig.InsecureSkipVerify {
+			t.Fatal("InsecureSkipVerify not correctly set on transport")
+		}
+	}
+}


### PR DESCRIPTION
As of [this commit](https://github.com/oracle/oci-go-sdk/commit/31bc76a6db6e9aec5f90a634e51c602b796aab93), oci-go-sdk stopped explicitly specifying the `Transport` on the http client it provides, such that `DefaultTransport` is used when the client is used (https://github.com/golang/go/blob/master/src/net/http/client.go#L60). Since we've started using this in fn_go, it's causing problems for the fn CLI. In the `disable-certs` true case in `fn_go`'s provider, we try and modify the `Transport` to set `TLSClientConfig.InsecureSkipVerify`, causing a panic as `DefaultTransport` has yet to be set: https://github.com/fnproject/fn_go/blob/master/provider/oracle/oracle_common.go#L145.

```
panic: interface conversion: http.RoundTripper is nil, not *http.Transport

goroutine 1 [running]:
github.com/fnproject/fn_go/provider/oracle.InsecureRoundTripper(...)
        /home/circleci/go/src/github.com/fnproject/cli/vendor/github.com/fnproject/fn_go/provider/oracle/oracle_common.go:146
github.com/fnproject/fn_go/provider/oracle.NewFromConfig(0x18869c0, 0x1d6ae80, 0x187a780, 0x1d6ae80, 0xc0003968b8, 0xc000724a01, 0xc000751fd8, 0x6)
        /home/circleci/go/src/github.com/fnproject/cli/vendor/github.com/fnproject/fn_go/provider/oracle/user_provider.go:46 +0x80b
github.com/fnproject/fn_go/provider.(*Providers).ProviderFromConfig(0x1d3ca88, 0xc000751fd8, 0x6, 0x18869c0, 0x1d6ae80, 0x187a780, 0x1d6ae80, 0x5, 0x4, 0xc00007e8c0, ...)
        /home/circleci/go/src/github.com/fnproject/cli/vendor/github.com/fnproject/fn_go/provider/provider.go:83 +0x96
github.com/fnproject/cli/client.CurrentProvider(0x1771442, 0x4, 0xc0000b2f60, 0x0)
        /home/circleci/go/src/github.com/fnproject/cli/client/api.go:11 +0x9a
github.com/fnproject/cli/objects/app.List.func1(0xc000378420, 0x177129e, 0x4)
        /home/circleci/go/src/github.com/fnproject/cli/objects/app/commands.go:57 +0x2f
github.com/urfave/cli.Command.Run(0x177129e, 0x4, 0x0, 0x0, 0xc000743b80, 0x2, 0x2, 0x1785a7a, 0x1d, 0x0, ...)
        /home/circleci/go/src/github.com/fnproject/cli/vendor/github.com/urfave/cli/command.go:198 +0xa96
github.com/urfave/cli.(*App).RunAsSubcommand(0xc0000969c0, 0xc000378160, 0x0, 0x0)
        /home/circleci/go/src/github.com/fnproject/cli/vendor/github.com/urfave/cli/app.go:379 +0x88b
github.com/urfave/cli.Command.startApp(0x17714fa, 0x4, 0x0, 0x0, 0xc000724290, 0x1, 0x1, 0x1789b28, 0x21, 0x0, ...)
        /home/circleci/go/src/github.com/fnproject/cli/vendor/github.com/urfave/cli/command.go:298 +0x81a
github.com/urfave/cli.Command.Run(0x17714fa, 0x4, 0x0, 0x0, 0xc000724290, 0x1, 0x1, 0x1789b28, 0x21, 0x0, ...)
        /home/circleci/go/src/github.com/fnproject/cli/vendor/github.com/urfave/cli/command.go:98 +0x1219
github.com/urfave/cli.(*App).Run(0xc0000964e0, 0xc00008c050, 0x5, 0x5, 0x0, 0x0)
        /home/circleci/go/src/github.com/fnproject/cli/vendor/github.com/urfave/cli/app.go:255 +0x741
main.main()
        /home/circleci/go/src/github.com/fnproject/cli/main.go:243 +0x60
```

We could either explicitly set `Transport` to `DefaultTransport` in the oci-go-sdk, or, as I've done in this PR, add the default inside the `InsecureRoundTripper` function.

Assuming we're happy with this, I'll then make a PR to update the version of `fn_go` in the CLI.