### PR TITLE
Allow clients to specify content type

### DIFF
--- a/provider/oracle/oracle_common.go
+++ b/provider/oracle/oracle_common.go
@@ -122,7 +122,9 @@ func (t ociSigningRoundTripper) signRequest(request *http.Request) (err error) {
 		return fmt.Errorf("Date header must be present and non-empty on request")
 	}
 	if request.Method == "POST" || request.Method == "PATCH" || request.Method == "PUT" {
-		request.Header.Set("Content-Type", "application/json")
+		if request.Header.Get("Content-Type") == "" {
+			request.Header.Set("Content-Type", "application/json")
+		}
 		request.Header.Set("Content-Length", fmt.Sprintf("%d", request.ContentLength))
 	}
 


### PR DESCRIPTION
At the moment the signer always overrides the content type of the request to be `application/json`. There's no need for this, and it means that there's no way to override the header when necessary.

This change checks to see if the content type header is set, and if the header is set then it's left as-is.